### PR TITLE
Fix #9674: Set max_retries for chord_unlock to prevent infinite retry…

### DIFF
--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -44,7 +44,7 @@ def add_unlock_chord_task(app):
     from celery.exceptions import ChordError
     from celery.result import allow_join_result, result_from_tuple
 
-    @app.task(name='celery.chord_unlock', max_retries=None, shared=False,
+    @app.task(name='celery.chord_unlock', max_retries=10, shared=False,
               default_retry_delay=app.conf.result_chord_retry_interval, ignore_result=True, lazy=False, bind=True)
     def unlock_chord(self, group_id, callback, interval=None,
                      max_retries=None, result=None,


### PR DESCRIPTION
Course Exercise:

## Description

This PR fixes issue #9674 where chord_unlock tasks enter an infinite retry loop when a task in a nested chain/group fails.

## Problem

When a task in a nested chain/group fails, the chord_unlock task enters an infinite retry loop because max_retries is set to None.

## Solution

Changed max_retries from None to 10 for the chord_unlock task in builtins.py. This ensures that the retry loop eventually terminates while still providing reasonable retry attempts.

## Related Issues
Fixes #9674
